### PR TITLE
Revert "Move defines to the top, fixing compiler errors" (PRESS-19463)

### DIFF
--- a/closure/goog/disposable/disposable.js
+++ b/closure/goog/disposable/disposable.js
@@ -24,23 +24,7 @@ goog.provide('goog.disposeAll');
 
 goog.require('goog.disposable.IDisposable');
 
-/**
- * @define {number} The monitoring mode of the goog.Disposable
- *     instances. Default is OFF. Switching on the monitoring is only
- *     recommended for debugging because it has a significant impact on
- *     performance and memory usage. If switched off, the monitoring code
- *     compiles down to 0 bytes.
- */
-goog.Disposable.MONITORING_MODE =
-    goog.define('goog.Disposable.MONITORING_MODE', 0);
 
-
-/**
- * @define {boolean} Whether to attach creation stack to each created disposable
- *     instance; This is only relevant for when MonitoringMode != OFF.
- */
-goog.Disposable.INCLUDE_STACK_ON_CREATION =
-    goog.define('goog.Disposable.INCLUDE_STACK_ON_CREATION', true);
 
 /**
  * Class that provides the basic implementation for disposable objects. If your
@@ -95,6 +79,26 @@ goog.Disposable.MonitoringMode = {
    */
   INTERACTIVE: 2
 };
+
+
+/**
+ * @define {number} The monitoring mode of the goog.Disposable
+ *     instances. Default is OFF. Switching on the monitoring is only
+ *     recommended for debugging because it has a significant impact on
+ *     performance and memory usage. If switched off, the monitoring code
+ *     compiles down to 0 bytes.
+ */
+goog.Disposable.MONITORING_MODE =
+    goog.define('goog.Disposable.MONITORING_MODE', 0);
+
+
+/**
+ * @define {boolean} Whether to attach creation stack to each created disposable
+ *     instance; This is only relevant for when MonitoringMode != OFF.
+ */
+goog.Disposable.INCLUDE_STACK_ON_CREATION =
+    goog.define('goog.Disposable.INCLUDE_STACK_ON_CREATION', true);
+
 
 /**
  * Maps the unique ID of every undisposed `goog.Disposable` object to


### PR DESCRIPTION
This reverts commit 893f2d473b6e38ad98387eb7428a71a6f4b70278.

This change breaks compilation with simple optimizations.